### PR TITLE
Add runtime dependency httparty

### DIFF
--- a/pinecone.gemspec
+++ b/pinecone.gemspec
@@ -9,4 +9,5 @@ Gem::Specification.new do |s|
   s.homepage    = "https://rubygems.org/gems/pinecone"
   s.metadata    = {"source_code_uri" => "https://github.com/ScotterC/pinecone"}
   s.license     = "MIT"
+  s.add_runtime_dependency "httparty", "~> 0.21.0"
 end


### PR DESCRIPTION
without the runtime dependency I get this error:

```
/Users/.../.rvm/gems/ruby-3.2.0/bundler/gems/pinecone-0e8cbf4d14b7/lib/pinecone.rb:1:in `require': cannot load such file -- httparty (LoadError)
```