### PR TITLE
Vector Query object with filter, sparse vector and ID support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-gem "rspec", "~> 3.12"
-gem "vcr", "~> 6.1"
-gem "dotenv", "~> 2.8"
-gem "httparty", "~> 0.21.0"
-gem "debug", "~> 1.7"
-gem "webmock", "~> 3.18"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,12 +2,18 @@ PATH
   remote: .
   specs:
     pinecone (0.1.2)
+      dotenv (~> 2.8)
+      dry-struct (~> 1.5.0)
+      dry-validation
+      httparty (~> 0.21.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
     addressable (2.8.1)
       public_suffix (>= 2.0.2, < 6.0)
+    awesome_print (1.9.2)
+    concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
     debug (1.7.1)
@@ -15,16 +21,59 @@ GEM
       reline (>= 0.3.1)
     diff-lcs (1.5.0)
     dotenv (2.8.1)
+    dry-configurable (0.16.1)
+      dry-core (~> 0.6)
+      zeitwerk (~> 2.6)
+    dry-container (0.11.0)
+      concurrent-ruby (~> 1.0)
+    dry-core (0.9.1)
+      concurrent-ruby (~> 1.0)
+      zeitwerk (~> 2.6)
+    dry-inflector (0.3.0)
+    dry-initializer (3.1.1)
+    dry-logic (1.3.0)
+      concurrent-ruby (~> 1.0)
+      dry-core (~> 0.9, >= 0.9)
+      zeitwerk (~> 2.6)
+    dry-schema (1.11.3)
+      concurrent-ruby (~> 1.0)
+      dry-configurable (~> 0.16, >= 0.16)
+      dry-core (~> 0.9, >= 0.9)
+      dry-initializer (~> 3.0)
+      dry-logic (~> 1.3)
+      dry-types (~> 1.6)
+      zeitwerk (~> 2.6)
+    dry-struct (1.5.2)
+      dry-core (~> 0.9, >= 0.9)
+      dry-types (~> 1.6)
+      ice_nine (~> 0.11)
+      zeitwerk (~> 2.6)
+    dry-types (1.6.1)
+      concurrent-ruby (~> 1.0)
+      dry-container (~> 0.3)
+      dry-core (~> 0.9, >= 0.9)
+      dry-inflector (~> 0.1, >= 0.1.2)
+      dry-logic (~> 1.3, >= 1.3)
+      zeitwerk (~> 2.6)
+    dry-validation (1.9.0)
+      concurrent-ruby (~> 1.0)
+      dry-container (~> 0.7, >= 0.7.1)
+      dry-core (~> 0.9, >= 0.9)
+      dry-initializer (~> 3.0)
+      dry-schema (~> 1.11, >= 1.11.0)
+      zeitwerk (~> 2.6)
     hashdiff (1.0.1)
     httparty (0.21.0)
       mini_mime (>= 1.0.0)
       multi_xml (>= 0.5.2)
+    ice_nine (0.11.2)
     io-console (0.6.0)
     irb (1.6.2)
       reline (>= 0.3.0)
     mini_mime (1.1.2)
     multi_xml (0.6.0)
     public_suffix (5.0.1)
+    rake (13.0.6)
     reline (0.3.2)
       io-console (~> 0.5)
     rexml (3.2.5)
@@ -46,19 +95,20 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
+    zeitwerk (2.6.7)
 
 PLATFORMS
   arm64-darwin-21
   x86_64-linux
 
 DEPENDENCIES
+  awesome_print
   debug (~> 1.7)
-  dotenv (~> 2.8)
-  httparty (~> 0.21.0)
   pinecone!
+  rake (~> 13.0)
   rspec (~> 3.12)
   vcr (~> 6.1)
-  webmock (~> 3.18)
+  webmock (~> 3.14)
 
 BUNDLED WITH
    2.4.3

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ pinecone.delete_index("example-index")
 ## Vector Operations
 
 Adding vectors to an existing index
+
 ```ruby
 pinecone = Pinecone::Client.new
 index = pinecone.index("example-index")
@@ -110,6 +111,71 @@ Deleting a vector from an index
   )
 ```
 
+### Filtering queries
+
+Add a `filter` option to apply filters to your query. You can use vector metadata to limit your search. See [metadata filtering](https://www.pinecone.io/docs/metadata-filtering/) in Pinecode documentation.
+
+```ruby
+  pinecone = Pinecone::Client.new
+  index = pinecone.index("example-index")
+  embedding = [0.0, -0.2, 0.4]
+  response = index.query(
+    vector: embedding,
+    filter: {
+      "genre": "comedy"
+    }
+  )
+```
+
+Metadata filters can be combined with AND and OR. Other operators are also supported.
+
+```ruby
+{ "$and": [{ "genre": "comedy" }, { "actor": "Brad Pitt" }] } # Genre is 'comedy' and actor is 'Brad Pitt'
+{ "$or": [{ "genre": "comedy" }, { "genre": "action" }] } # Genre is 'comedy' or 'action'
+{ "genre": { "$eq": "comedy" }} # Genre is 'comedy'
+{ "favorite": { "$eq": true }} # Is a favorite
+{ "genre": { "$ne": "comedy" }} # Genre is not 'comedy'
+{ "favorite": { "$ne": true }} # Is not a favorite
+{ "genre": { "$in": ["comedy", "action"] }} # Genre is in the specified values
+{ "genre": { "$nin": ["comedy", "action"] }} # Genre is not in the specified values
+{ "$gt": 1 }
+{ "$gte": 0.5 }
+{ "$lt": -0.5 }
+{ "$lte": -1 }
+```
+
+Specifying an invalid filter raises `ArgumentError` with an error message.
+
+### Sparse Vectors
+
+```ruby
+  pinecone = Pinecone::Client.new
+  index = pinecone.index("example-index")
+  embedding = [0.0, -0.2, 0.4]
+  response = index.query(
+    vector: embedding,
+    sparse_vector: {
+      indices: [10, 20, 30],
+      values: [0, 0.5, -1]
+    }
+  )
+```
+
+The length of indices and values must match.
+
+### Query by ID
+
+```ruby
+  pinecone = Pinecone::Client.new
+  index = pinecone.index("example-index")
+  embedding = [0.0, -0.2, 0.4]
+  response = index.query(
+    id: "vector1"
+  )
+```
+
+Either `vector` or `id` can be supplied as a query parameter, not both. This constraint is validated.
+
 ## Collection Operations
 
 Creating a collection
@@ -141,11 +207,11 @@ Delete a collection
 
 ## TODO
 
-- Add filter, sparse vector and id options to query request
-- Add functionality for
-  - POST Describe Index Stats
-  - POST Update Vectors
-  - Patch configure_index
+- [x] Add filter, sparse vector and id options to query request
+- [ ] Add functionality for
+  - [ ] POST Describe Index Stats
+  - [ ] POST Update Vectors
+  - [ ] Patch configure_index
 
 ## Contributing
 

--- a/lib/pinecone/vector/filter.rb
+++ b/lib/pinecone/vector/filter.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require "dry-struct"
+require "dry-validation"
+
+module Types
+  include Dry.Types()
+
+  StringOrNumberOrBoolean = Dry::Types['string'] | Dry::Types['integer'] | Dry::Types['float'] | Dry::Types['bool']
+  StringOrNumber = Dry::Types['string'] | Dry::Types['integer'] | Dry::Types['float']
+  Number = Dry::Types['integer'] | Dry::Types['float']
+end
+
+module Pinecone
+  class Vector
+    class Filter < Hash
+      class FilterContract < Dry::Validation::Contract
+        schema do
+          optional(:$and).filled(:array)
+          optional(:$or).filled(:array)
+          optional(:$eq).filled(Types::StringOrNumberOrBoolean)
+          optional(:$ne).filled(Types::StringOrNumberOrBoolean)
+          optional(:$gt).filled(Types::Number)
+          optional(:$gte).filled(Types::Number)
+          optional(:$lt).filled(Types::Number)
+          optional(:$lte).filled(Types::Number)
+          optional(:$in).filled(:array).each(Types::StringOrNumber)
+          optional(:$nin).filled(:array).each(Types::StringOrNumber)
+        end
+
+        rule(:$and) do
+          if key?
+            key(:$and).failure("'$any' must be an array") unless value.is_a?(Array)
+
+            value.each do |v|
+              key(:$and).failure("'$any' must be an array of filters") unless v.is_a?(Filter) || to_filter(v).is_a?(Filter)
+            end
+          end
+        end
+
+        rule(:$or) do
+          if key?
+            key(:$or).failure("'$or' must be an array") unless value.is_a?(Array)
+
+            value.each do |v|
+              key(:$or).failure("'$or' must be an array of filters") unless v.is_a?(Filter) || to_filter(v).is_a?(Filter)
+            end
+          end
+        end
+
+        def to_filter(input)
+          return false unless input.is_a?(Hash)
+          return Filter.new(input)
+        end
+      end
+
+      def self.new(input)
+        validation = FilterContract.new.call(input)
+        if validation.success?
+          super(input)
+        else
+          raise ArgumentError.new(validation.errors.to_h.inspect)
+        end
+      end
+
+      def self.default?
+        nil
+      end
+    end
+  end
+end

--- a/lib/pinecone/vector/query.rb
+++ b/lib/pinecone/vector/query.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "dry-struct"
+require "dry-validation"
+
+require "pinecone/vector/filter"
+require "pinecone/vector/sparse_vector"
+
+module Types
+  include Dry.Types()
+end
+
+module Pinecone
+  class Vector
+    class Query < Dry::Struct
+      class QueryContract < Dry::Validation::Contract
+        params do
+          optional(:vector).filled(:array)
+          optional(:id).filled(:string)
+        end
+
+        rule(:vector, :id) do
+          if !values[:vector].nil? && !values[:id].nil?
+            key(:vector).failure("Only one of vector or id can be specified")
+            key(:id).failure("Only one of vector or id can be specified")
+          end
+        end
+      end
+
+      schema schema.strict
+
+      attribute :namespace, Dry::Types['string'].default("")
+      attribute :include_values, Dry::Types['bool'].default(false)
+      attribute :include_metadata, Dry::Types['bool'].default(true)
+      attribute :top_k, Dry::Types['integer'].default(10)
+      attribute? :vector, Dry::Types['array'].of(Dry::Types['float'] | Dry::Types['integer'])
+      attribute? :filter, Filter
+      attribute? :sparse_vector, SparseVector
+      attribute? :id, Dry::Types['string']
+
+      def self.new(input)
+        validation = QueryContract.new.call(input)
+        if validation.success?
+          super(input)
+        else
+          raise ArgumentError.new(validation.errors.to_h.inspect)
+        end
+      end
+
+      def to_json
+        to_h.map do |key, value|
+          [key.to_s.split("_").map.with_index do |word, index|
+            index == 0 ? word : word.capitalize
+          end.join.to_sym, value]
+        end.to_h.to_json
+      end
+    end
+  end
+end

--- a/lib/pinecone/vector/sparse_vector.rb
+++ b/lib/pinecone/vector/sparse_vector.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "dry-struct"
+require "dry-validation"
+
+module Types
+  include Dry.Types()
+end
+
+module Pinecone
+  class Vector
+    class SparseVector < Dry::Struct
+      class SparseVectorContract < Dry::Validation::Contract
+        params do
+          required(:indices).filled(:array)
+          required(:values).filled(:array)
+        end
+
+        rule(:indices, :values) do
+          unless values[:indices].size === values[:values].size
+            key(:indices).failure("Indices and values must be the same size")
+            key(:values).failure("Indices and values must be the same size")
+          end
+        end
+      end
+
+      attribute :indices, Dry::Types['array'].of(Dry::Types['integer'])
+      attribute :values, Dry::Types['array'].of(Dry::Types['float'] | Dry::Types['integer'])
+
+      def self.new(input)
+        validation = SparseVectorContract.new.call(input)
+        if validation.success?
+          super(input)
+        else
+          raise ArgumentError.new(validation.errors.to_h.inspect)
+        end
+      end
+    end
+  end
+end

--- a/pinecone.gemspec
+++ b/pinecone.gemspec
@@ -3,10 +3,22 @@ Gem::Specification.new do |s|
   s.version     = "0.1.2"
   s.summary     = "Ruby client library for Pinecone Vector DB"
   s.description = "Ruby client library which includes index and vector operations to upload embeddings into Pinecone and do similarity searches on them."
-  s.authors     = ["Scott Carleton"]
-  s.email       = "scott@extrayarn.com"
+  s.authors     = ["Scott Carleton", "Lauri Jutila"]
+  s.email       = ["scott@extrayarn.com", "git@laurijutila.com"]
   s.files       = ["lib/pinecone.rb"]
   s.homepage    = "https://rubygems.org/gems/pinecone"
   s.metadata    = {"source_code_uri" => "https://github.com/ScotterC/pinecone"}
   s.license     = "MIT"
+
+  s.add_dependency "dotenv", "~> 2.8"
+  s.add_dependency "httparty", "~> 0.21.0"
+  s.add_dependency "dry-struct", "~> 1.5.0"
+  s.add_dependency "dry-validation"
+
+  s.add_development_dependency "awesome_print"
+  s.add_development_dependency "rake", "~> 13.0"
+  s.add_development_dependency "debug", "~> 1.7"
+  s.add_development_dependency "rspec", "~> 3.12"
+  s.add_development_dependency "webmock", "~> 3.14"
+  s.add_development_dependency "vcr", "~> 6.1"
 end

--- a/spec/pinecone/vector/filter_spec.rb
+++ b/spec/pinecone/vector/filter_spec.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Pinecone
+  RSpec.describe Vector::Filter do
+    describe "Validations" do
+      context "when $and is specified" do
+        let(:filter) { described_class.new("$and": [{ "genre": "comedy" }, { "genre": "drama" }]) }
+        let(:invalid_filter) { described_class.new("$and": [1, 2, 3]) }
+
+        it "raises an error" do
+          expect{ invalid_filter }.to raise_error(ArgumentError)
+        end
+
+        it "does not raise error with valid filter" do
+          expect{ filter }.not_to raise_error
+        end
+      end
+
+      context "when $or is specified" do
+        let(:filter) { described_class.new("$or": [{ "genre": "comedy" }, { "genre": "drama" }]) }
+        let(:invalid_filter) { described_class.new("$or": [1, "foo", 3]) }
+
+        it "raises an error" do
+          expect{ invalid_filter }.to raise_error(ArgumentError)
+        end
+
+        it "does not raise error with valid filter" do
+          expect{ filter }.not_to raise_error
+        end
+      end
+
+      context "when $eq is specified" do
+        let(:filter) { described_class.new("$eq": 1) }
+        let(:invalid_filter) { described_class.new("$eq": ["foo", "bar"]) }
+
+        it "does not raise an error with a valid filter" do
+          expect{ filter }.not_to raise_error
+        end
+
+        it "raises an error with an invalid filter" do
+          expect{ invalid_filter }.to raise_error(ArgumentError)
+        end
+      end
+
+      context "when $ne is specified" do
+        let(:filter) { described_class.new("$ne": 1) }
+        let(:invalid_filter) { described_class.new("$ne": ["foo", "bar"]) }
+
+        it "does not raise an error with a valid filter" do
+          expect{ filter }.not_to raise_error
+        end
+
+        it "raises an error with an invalid filter" do
+          expect{ invalid_filter }.to raise_error(ArgumentError)
+        end
+      end
+
+      [ "$lt", "$lte", "$gt", "$gte" ].each do |operator|
+        context "when #{operator} is specified" do
+          let(:filter) { described_class.new("#{operator}": 1) }
+          let(:filter_2) { described_class.new("#{operator}": 1.5) }
+          let(:invalid_filter) { described_class.new("#{operator}": ["foo", "bar"]) }
+          let(:invalid_filter_2) { described_class.new("#{operator}": "foo") }
+  
+          it "does not raise an error with a valid filter" do
+            expect{ filter }.not_to raise_error
+            expect{ filter_2 }.not_to raise_error
+          end
+  
+          it "raises an error with an invalid filter" do
+            expect{ invalid_filter }.to raise_error(ArgumentError)
+            expect{ invalid_filter_2 }.to raise_error(ArgumentError)
+          end
+        end
+      end
+
+      context "when $in is specified" do
+        let(:filter) { described_class.new("$in": [1, "foo", 3]) }
+        let(:invalid_filter) { described_class.new("$in": "foo") }
+        let(:invalid_filter_2) { described_class.new("$in": [1, true, "bar"]) }
+
+        it "does not raise an error with a valid filter" do
+          expect{ filter }.not_to raise_error
+        end
+
+        it "raises an error with an invalid filter" do
+          expect{ invalid_filter }.to raise_error(ArgumentError)
+          expect{ invalid_filter_2 }.to raise_error(ArgumentError)
+        end
+      end
+
+      context "when $nin is specified" do
+        let(:filter) { described_class.new("$nin": [1, "foo", 3]) }
+        let(:invalid_filter) { described_class.new("$nin": "foo") }
+        let(:invalid_filter_2) { described_class.new("$nin": [1, true, "bar"]) }
+
+        it "does not raise an error with a valid filter" do
+          expect{ filter }.not_to raise_error
+        end
+
+        it "raises an error with an invalid filter" do
+          expect{ invalid_filter }.to raise_error(ArgumentError)
+          expect{ invalid_filter_2 }.to raise_error(ArgumentError)
+        end
+      end
+    end
+  end
+end

--- a/spec/pinecone/vector/query_spec.rb
+++ b/spec/pinecone/vector/query_spec.rb
@@ -1,0 +1,84 @@
+require "spec_helper"
+
+module Pinecone
+  RSpec.describe Vector::Query do
+    describe "Defaults" do
+      let(:vector) { [0, 0.5, -0.5] }
+      let(:query) { described_class.new(vector: vector) }
+
+      it "has a default namespace" do
+        expect(query.namespace).to eq("")
+      end
+
+      it "has a default include_values" do
+        expect(query.include_values).to eq(false)
+      end
+
+      it "has a default include_metadata" do
+        expect(query.include_metadata).to eq(true)
+      end
+
+      it "has a default top_k" do
+        expect(query.top_k).to eq(10)
+      end
+    end
+
+    describe "Validations" do
+      context "when vector and id are both specified" do
+        let(:vector) { [0, 0.5, -0.5] }
+        let(:query) { described_class.new(vector: vector, id: "foo") }
+
+        it "raises an error" do
+          expect{ query }.to raise_error(ArgumentError)
+        end
+      end
+    end
+
+    describe "Vector" do
+      context "must be an array of floats and/or integers" do
+        let(:vector) { [0, 0.5, -0.5] }
+        let(:query) { described_class.new(vector: vector) }
+
+        it "is valid" do
+          expect{ query }.not_to raise_error
+          expect(query.vector).to eq(vector)
+        end
+
+        context "all integers" do
+          let(:vector) { [0, 1, -1] }
+
+          it { expect{ query }.not_to raise_error }
+        end
+
+        context "all floats" do
+          let(:vector) { [0.0, 0.5, -0.5] }
+
+          it { expect{ query }.not_to raise_error }          
+        end
+
+        context "with a non-numeric value" do
+          let(:vector) { [0, 0.5, "foo"] }
+
+          it "raises an error" do
+            expect { query }.to raise_error(Dry::Struct::Error)
+          end
+        end
+      end
+    end
+
+    describe "#to_h" do
+      let(:vector) { [0, 0.5, -0.5] }
+      let(:query) { described_class.new(vector: vector) }
+
+      it "returns a hash" do
+        expect(query.to_h).to eq({
+          namespace: "",
+          include_values: false,
+          include_metadata: true,
+          top_k: 10,
+          vector: [0, 0.5, -0.5]
+        })
+      end
+    end
+  end
+end

--- a/spec/pinecone/vector_spec.rb
+++ b/spec/pinecone/vector_spec.rb
@@ -98,31 +98,48 @@ RSpec.describe Pinecone::Vector do
 
       let(:response) {
         index.query(vector: query_vector)
-      } 
+      }
+
+      let(:query_object) {
+        Pinecone::Vector::Query.new(vector: query_vector)
+      }
+
+      let(:response_with_object) {
+        index.query(query_object)
+      }
+
+      let(:valid_result) {
+        {
+          "results" => [],
+          "matches" => [
+            {
+                "id" => "3",
+                "score" => 1,
+                "values" => []
+            },
+            {
+                "id" => "2",
+                "score" => -0.5,
+                "values" => []
+            },
+            {
+                "id" => "1",
+                "score" => -0.5,
+                "values" => []
+            }
+          ],
+          "namespace" => ""
+        }
+      }
   
       it "returns a response" do
         expect(response).to be_a(HTTParty::Response)
-        expect(response.parsed_response).to eq({
-              "results" => [],
-              "matches" => [
-                {
-                        "id" => "3",
-                    "score" => 1,
-                    "values" => []
-                },
-                {
-                        "id" => "2",
-                    "score" => -0.5,
-                    "values" => []
-                },
-                {
-                        "id" => "1",
-                    "score" => -0.5,
-                    "values" => []
-                }
-            ],
-            "namespace" => ""
-        })
+        expect(response.parsed_response).to eq(valid_result)
+      end
+
+      it "returns a response when queried with object" do
+        expect(response_with_object).to be_a(HTTParty::Response)
+        expect(response_with_object.parsed_response).to eq(valid_result)        
       end
     end
 
@@ -141,17 +158,17 @@ RSpec.describe Pinecone::Vector do
           "results" => [],
           "matches" => [
             {
-                    "id" => "3",
+                "id" => "3",
                 "score" => 1,
                 "values" => []
             },
             {
-                    "id" => "2",
+                "id" => "2",
                 "score" => -0.5,
                 "values" => []
             },
             {
-                    "id" => "1",
+                "id" => "1",
                 "score" => -0.5,
                 "values" => []
             }


### PR DESCRIPTION
This PR changes `Vector#query` to build and use a `Query` object to build a valid query before making the API call. If the query object is not valid, errors are raised.

It also adds support for:

- filters
- sparse vectors
- querying by ID

I extracted this from my Pinecone client, which isn't yet as feature complete as this gem.

Note: this PR adds new dependencies as I'm using `dry-rb` gems for schema and validation of `Query` object and its child objects. I hope that you are OK with this.