### PR TITLE
Enabling delete_all on Vector#delete

### DIFF
--- a/lib/pinecone/vector.rb
+++ b/lib/pinecone/vector.rb
@@ -24,8 +24,10 @@ module Pinecone
         "ids": ids,
         "deleteAll": delete_all,
         "filter": filter,
-      }.to_json
-      payload = options.merge(body: inputs)
+      }
+      
+      inputs.delete(:filter) if delete_all || ids.any?
+      payload = options.merge(body: inputs.to_json)
       self.class.post("#{@base_uri}/vectors/delete", payload)
     end
 

--- a/spec/cassettes/Pinecone_Vector/_delete/successful_response/returns_a_response.yml
+++ b/spec/cassettes/Pinecone_Vector/_delete/successful_response/returns_a_response.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://example-index-b2e8921.svc.<PINECONE_ENVIRONMENT>.pinecone.io/vectors/upsert
+    uri: https://example-index-1-b2e8921.svc.<PINECONE_ENVIRONMENT>.pinecone.io/vectors/upsert
     body:
       encoding: UTF-8
       string: '{"vectors":[{"values":[1,2,3],"id":"5"}]}'
@@ -25,9 +25,9 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Mar 2023 01:00:43 GMT
+      - Mon, 12 Jun 2023 18:54:53 GMT
       X-Envoy-Upstream-Service-Time:
-      - '10'
+      - '8'
       Grpc-Status:
       - '0'
       Content-Length:
@@ -37,10 +37,10 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"upsertedCount":1}'
-  recorded_at: Tue, 21 Mar 2023 01:00:44 GMT
+  recorded_at: Mon, 12 Jun 2023 18:54:53 GMT
 - request:
     method: post
-    uri: https://example-index-b2e8921.svc.<PINECONE_ENVIRONMENT>.pinecone.io/vectors/delete
+    uri: https://example-index-1-b2e8921.svc.<PINECONE_ENVIRONMENT>.pinecone.io/vectors/delete
     body:
       encoding: UTF-8
       string: '{"namespace":"","ids":["5"],"deleteAll":false}'
@@ -63,9 +63,9 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Mar 2023 01:12:30 GMT
+      - Mon, 12 Jun 2023 18:54:53 GMT
       X-Envoy-Upstream-Service-Time:
-      - '10'
+      - '7'
       Grpc-Status:
       - '0'
       Content-Length:
@@ -75,5 +75,43 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "{}"
-  recorded_at: Tue, 21 Mar 2023 01:12:30 GMT
+  recorded_at: Mon, 12 Jun 2023 18:54:54 GMT
+- request:
+    method: post
+    uri: https://example-index-1-b2e8921.svc.<PINECONE_ENVIRONMENT>.pinecone.io/vectors/delete
+    body:
+      encoding: UTF-8
+      string: '{"namespace":"","ids":[],"deleteAll":true}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Api-Key:
+      - "<PINECONE_API_KEY>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 12 Jun 2023 18:54:53 GMT
+      X-Envoy-Upstream-Service-Time:
+      - '11'
+      Grpc-Status:
+      - '0'
+      Content-Length:
+      - '2'
+      Server:
+      - envoy
+    body:
+      encoding: UTF-8
+      string: "{}"
+  recorded_at: Mon, 12 Jun 2023 18:54:54 GMT
 recorded_with: VCR 6.1.0

--- a/spec/cassettes/Pinecone_Vector/_delete/successful_response_with_filters/returns_a_response.yml
+++ b/spec/cassettes/Pinecone_Vector/_delete/successful_response_with_filters/returns_a_response.yml
@@ -2,48 +2,10 @@
 http_interactions:
 - request:
     method: post
-    uri: https://example-index-b2e8921.svc.<PINECONE_ENVIRONMENT>.pinecone.io/describe_index_stats
-    body:
-      encoding: UTF-8
-      string: '{"filter":{"genre":{"$eq":"comedy"}}}'
-    headers:
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      Api-Key:
-      - "<PINECONE_API_KEY>"
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 26 Apr 2023 15:52:39 GMT
-      X-Envoy-Upstream-Service-Time:
-      - '1'
-      Grpc-Status:
-      - '0'
-      Content-Length:
-      - '70'
-      Server:
-      - envoy
-    body:
-      encoding: UTF-8
-      string: '{"namespaces":{},"dimension":3,"indexFullness":0,"totalVectorCount":3}'
-  recorded_at: Wed, 26 Apr 2023 15:52:39 GMT
-- request:
-    method: post
     uri: https://example-index-1-b2e8921.svc.<PINECONE_ENVIRONMENT>.pinecone.io/vectors/upsert
     body:
       encoding: UTF-8
-      string: '{"vectors":[{"values":[1,2,3],"id":"1","metadata":{"genre":"comedy"}},{"values":[0,1,-1],"id":"2","metadata":{"genre":"comedy"}},{"values":[1,-1,0],"id":"3"}]}'
+      string: '{"vectors":[{"values":[1,2,3],"id":"5"}]}'
     headers:
       Content-Type:
       - application/json
@@ -63,9 +25,9 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 12 Jun 2023 18:55:01 GMT
+      - Mon, 12 Jun 2023 18:54:54 GMT
       X-Envoy-Upstream-Service-Time:
-      - '50'
+      - '26'
       Grpc-Status:
       - '0'
       Content-Length:
@@ -74,14 +36,14 @@ http_interactions:
       - envoy
     body:
       encoding: UTF-8
-      string: '{"upsertedCount":3}'
-  recorded_at: Mon, 12 Jun 2023 18:55:01 GMT
+      string: '{"upsertedCount":1}'
+  recorded_at: Mon, 12 Jun 2023 18:54:54 GMT
 - request:
     method: post
-    uri: https://example-index-1-b2e8921.svc.<PINECONE_ENVIRONMENT>.pinecone.io/describe_index_stats
+    uri: https://example-index-1-b2e8921.svc.<PINECONE_ENVIRONMENT>.pinecone.io/vectors/delete
     body:
       encoding: UTF-8
-      string: '{"filter":{"genre":{"$eq":"comedy"}}}'
+      string: '{"namespace":"","ids":[],"deleteAll":false,"filter":{"genre":"comedy"}}'
     headers:
       Content-Type:
       - application/json
@@ -101,19 +63,19 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 12 Jun 2023 18:55:01 GMT
+      - Mon, 12 Jun 2023 18:54:54 GMT
       X-Envoy-Upstream-Service-Time:
-      - '0'
+      - '8'
       Grpc-Status:
       - '0'
       Content-Length:
-      - '90'
+      - '2'
       Server:
       - envoy
     body:
       encoding: UTF-8
-      string: '{"namespaces":{"":{"vectorCount":2}},"dimension":3,"indexFullness":0,"totalVectorCount":3}'
-  recorded_at: Mon, 12 Jun 2023 18:55:01 GMT
+      string: "{}"
+  recorded_at: Mon, 12 Jun 2023 18:54:54 GMT
 - request:
     method: post
     uri: https://example-index-1-b2e8921.svc.<PINECONE_ENVIRONMENT>.pinecone.io/vectors/delete
@@ -139,9 +101,9 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 12 Jun 2023 18:55:01 GMT
+      - Mon, 12 Jun 2023 18:54:54 GMT
       X-Envoy-Upstream-Service-Time:
-      - '11'
+      - '7'
       Grpc-Status:
       - '0'
       Content-Length:
@@ -151,5 +113,5 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "{}"
-  recorded_at: Mon, 12 Jun 2023 18:55:01 GMT
+  recorded_at: Mon, 12 Jun 2023 18:54:54 GMT
 recorded_with: VCR 6.1.0

--- a/spec/cassettes/Pinecone_Vector/_delete/when_delete_all_is_true/returns_a_response.yml
+++ b/spec/cassettes/Pinecone_Vector/_delete/when_delete_all_is_true/returns_a_response.yml
@@ -2,48 +2,10 @@
 http_interactions:
 - request:
     method: post
-    uri: https://example-index-b2e8921.svc.<PINECONE_ENVIRONMENT>.pinecone.io/describe_index_stats
-    body:
-      encoding: UTF-8
-      string: '{"filter":{"genre":{"$eq":"comedy"}}}'
-    headers:
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      Api-Key:
-      - "<PINECONE_API_KEY>"
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 26 Apr 2023 15:52:39 GMT
-      X-Envoy-Upstream-Service-Time:
-      - '1'
-      Grpc-Status:
-      - '0'
-      Content-Length:
-      - '70'
-      Server:
-      - envoy
-    body:
-      encoding: UTF-8
-      string: '{"namespaces":{},"dimension":3,"indexFullness":0,"totalVectorCount":3}'
-  recorded_at: Wed, 26 Apr 2023 15:52:39 GMT
-- request:
-    method: post
     uri: https://example-index-1-b2e8921.svc.<PINECONE_ENVIRONMENT>.pinecone.io/vectors/upsert
     body:
       encoding: UTF-8
-      string: '{"vectors":[{"values":[1,2,3],"id":"1","metadata":{"genre":"comedy"}},{"values":[0,1,-1],"id":"2","metadata":{"genre":"comedy"}},{"values":[1,-1,0],"id":"3"}]}'
+      string: '{"vectors":[{"values":[1,2,3],"id":"5"}]}'
     headers:
       Content-Type:
       - application/json
@@ -63,9 +25,9 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 12 Jun 2023 18:55:01 GMT
+      - Mon, 12 Jun 2023 18:54:54 GMT
       X-Envoy-Upstream-Service-Time:
-      - '50'
+      - '8'
       Grpc-Status:
       - '0'
       Content-Length:
@@ -74,46 +36,8 @@ http_interactions:
       - envoy
     body:
       encoding: UTF-8
-      string: '{"upsertedCount":3}'
-  recorded_at: Mon, 12 Jun 2023 18:55:01 GMT
-- request:
-    method: post
-    uri: https://example-index-1-b2e8921.svc.<PINECONE_ENVIRONMENT>.pinecone.io/describe_index_stats
-    body:
-      encoding: UTF-8
-      string: '{"filter":{"genre":{"$eq":"comedy"}}}'
-    headers:
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      Api-Key:
-      - "<PINECONE_API_KEY>"
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 12 Jun 2023 18:55:01 GMT
-      X-Envoy-Upstream-Service-Time:
-      - '0'
-      Grpc-Status:
-      - '0'
-      Content-Length:
-      - '90'
-      Server:
-      - envoy
-    body:
-      encoding: UTF-8
-      string: '{"namespaces":{"":{"vectorCount":2}},"dimension":3,"indexFullness":0,"totalVectorCount":3}'
-  recorded_at: Mon, 12 Jun 2023 18:55:01 GMT
+      string: '{"upsertedCount":1}'
+  recorded_at: Mon, 12 Jun 2023 18:54:55 GMT
 - request:
     method: post
     uri: https://example-index-1-b2e8921.svc.<PINECONE_ENVIRONMENT>.pinecone.io/vectors/delete
@@ -139,9 +63,9 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 12 Jun 2023 18:55:01 GMT
+      - Mon, 12 Jun 2023 18:54:54 GMT
       X-Envoy-Upstream-Service-Time:
-      - '11'
+      - '8'
       Grpc-Status:
       - '0'
       Content-Length:
@@ -151,5 +75,43 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "{}"
-  recorded_at: Mon, 12 Jun 2023 18:55:01 GMT
+  recorded_at: Mon, 12 Jun 2023 18:54:55 GMT
+- request:
+    method: post
+    uri: https://example-index-1-b2e8921.svc.<PINECONE_ENVIRONMENT>.pinecone.io/vectors/delete
+    body:
+      encoding: UTF-8
+      string: '{"namespace":"","ids":[],"deleteAll":true}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Api-Key:
+      - "<PINECONE_API_KEY>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 12 Jun 2023 18:54:54 GMT
+      X-Envoy-Upstream-Service-Time:
+      - '7'
+      Grpc-Status:
+      - '0'
+      Content-Length:
+      - '2'
+      Server:
+      - envoy
+    body:
+      encoding: UTF-8
+      string: "{}"
+  recorded_at: Mon, 12 Jun 2023 18:54:55 GMT
 recorded_with: VCR 6.1.0

--- a/spec/cassettes/Pinecone_Vector/_describe_index_stats/returns_a_successful_response.yml
+++ b/spec/cassettes/Pinecone_Vector/_describe_index_stats/returns_a_successful_response.yml
@@ -2,7 +2,45 @@
 http_interactions:
 - request:
     method: post
-    uri: https://example-index-b2e8921.svc.<PINECONE_ENVIRONMENT>.pinecone.io/describe_index_stats
+    uri: https://example-index-1-b2e8921.svc.<PINECONE_ENVIRONMENT>.pinecone.io/vectors/upsert
+    body:
+      encoding: UTF-8
+      string: '{"vectors":[{"values":[1,2,3],"id":"1","metadata":{"genre":"comedy"}},{"values":[0,1,-1],"id":"2","metadata":{"genre":"comedy"}},{"values":[1,-1,0],"id":"3"}]}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Api-Key:
+      - "<PINECONE_API_KEY>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 12 Jun 2023 18:55:00 GMT
+      X-Envoy-Upstream-Service-Time:
+      - '49'
+      Grpc-Status:
+      - '0'
+      Content-Length:
+      - '19'
+      Server:
+      - envoy
+    body:
+      encoding: UTF-8
+      string: '{"upsertedCount":3}'
+  recorded_at: Mon, 12 Jun 2023 18:55:00 GMT
+- request:
+    method: post
+    uri: https://example-index-1-b2e8921.svc.<PINECONE_ENVIRONMENT>.pinecone.io/describe_index_stats
     body:
       encoding: UTF-8
       string: ''
@@ -25,9 +63,9 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 26 Apr 2023 14:46:38 GMT
+      - Mon, 12 Jun 2023 18:55:00 GMT
       X-Envoy-Upstream-Service-Time:
-      - '1'
+      - '0'
       Grpc-Status:
       - '0'
       Content-Length:
@@ -37,5 +75,43 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"namespaces":{"":{"vectorCount":3}},"dimension":3,"indexFullness":0,"totalVectorCount":3}'
-  recorded_at: Wed, 26 Apr 2023 14:46:38 GMT
+  recorded_at: Mon, 12 Jun 2023 18:55:01 GMT
+- request:
+    method: post
+    uri: https://example-index-1-b2e8921.svc.<PINECONE_ENVIRONMENT>.pinecone.io/vectors/delete
+    body:
+      encoding: UTF-8
+      string: '{"namespace":"","ids":[],"deleteAll":true}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Api-Key:
+      - "<PINECONE_API_KEY>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 12 Jun 2023 18:55:00 GMT
+      X-Envoy-Upstream-Service-Time:
+      - '9'
+      Grpc-Status:
+      - '0'
+      Content-Length:
+      - '2'
+      Server:
+      - envoy
+    body:
+      encoding: UTF-8
+      string: "{}"
+  recorded_at: Mon, 12 Jun 2023 18:55:01 GMT
 recorded_with: VCR 6.1.0

--- a/spec/cassettes/Pinecone_Vector/_fetch/successful_response/returns_a_response.yml
+++ b/spec/cassettes/Pinecone_Vector/_fetch/successful_response/returns_a_response.yml
@@ -114,4 +114,156 @@ http_interactions:
       encoding: UTF-8
       string: '{"vectors":{"1":{"id":"1","values":[1,2,3]},"2":{"id":"2","values":[1,2,3]}},"namespace":""}'
   recorded_at: Mon, 27 Mar 2023 18:52:04 GMT
+- request:
+    method: post
+    uri: https://example-index-1-b2e8921.svc.<PINECONE_ENVIRONMENT>.pinecone.io/vectors/upsert
+    body:
+      encoding: UTF-8
+      string: '{"vectors":[{"values":[1,2,3],"id":"1"}]}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Api-Key:
+      - "<PINECONE_API_KEY>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 12 Jun 2023 18:54:55 GMT
+      X-Envoy-Upstream-Service-Time:
+      - '8'
+      Grpc-Status:
+      - '0'
+      Content-Length:
+      - '19'
+      Server:
+      - envoy
+    body:
+      encoding: UTF-8
+      string: '{"upsertedCount":1}'
+  recorded_at: Mon, 12 Jun 2023 18:54:55 GMT
+- request:
+    method: post
+    uri: https://example-index-1-b2e8921.svc.<PINECONE_ENVIRONMENT>.pinecone.io/vectors/upsert
+    body:
+      encoding: UTF-8
+      string: '{"vectors":[{"values":[1,2,3],"id":"2"}]}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Api-Key:
+      - "<PINECONE_API_KEY>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 12 Jun 2023 18:54:55 GMT
+      X-Envoy-Upstream-Service-Time:
+      - '8'
+      Grpc-Status:
+      - '0'
+      Content-Length:
+      - '19'
+      Server:
+      - envoy
+    body:
+      encoding: UTF-8
+      string: '{"upsertedCount":1}'
+  recorded_at: Mon, 12 Jun 2023 18:54:55 GMT
+- request:
+    method: get
+    uri: https://example-index-1-b2e8921.svc.<PINECONE_ENVIRONMENT>.pinecone.io/vectors/fetch?ids=2&namespace=
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Api-Key:
+      - "<PINECONE_API_KEY>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 12 Jun 2023 18:54:55 GMT
+      X-Envoy-Upstream-Service-Time:
+      - '0'
+      Grpc-Status:
+      - '0'
+      Content-Length:
+      - '92'
+      Server:
+      - envoy
+    body:
+      encoding: UTF-8
+      string: '{"vectors":{"1":{"id":"1","values":[1,2,3]},"2":{"id":"2","values":[1,2,3]}},"namespace":""}'
+  recorded_at: Mon, 12 Jun 2023 18:54:56 GMT
+- request:
+    method: post
+    uri: https://example-index-1-b2e8921.svc.<PINECONE_ENVIRONMENT>.pinecone.io/vectors/delete
+    body:
+      encoding: UTF-8
+      string: '{"namespace":"","ids":[],"deleteAll":true}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Api-Key:
+      - "<PINECONE_API_KEY>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 12 Jun 2023 18:54:55 GMT
+      X-Envoy-Upstream-Service-Time:
+      - '7'
+      Grpc-Status:
+      - '0'
+      Content-Length:
+      - '2'
+      Server:
+      - envoy
+    body:
+      encoding: UTF-8
+      string: "{}"
+  recorded_at: Mon, 12 Jun 2023 18:54:56 GMT
 recorded_with: VCR 6.1.0

--- a/spec/cassettes/Pinecone_Vector/_query/missing_index/raises_an_exception.yml
+++ b/spec/cassettes/Pinecone_Vector/_query/missing_index/raises_an_exception.yml
@@ -38,4 +38,42 @@ http_interactions:
       encoding: UTF-8
       string: '{"upsertedCount":3}'
   recorded_at: Fri, 24 Feb 2023 20:41:44 GMT
+- request:
+    method: post
+    uri: https://example-index-1-b2e8921.svc.<PINECONE_ENVIRONMENT>.pinecone.io/vectors/delete
+    body:
+      encoding: UTF-8
+      string: '{"namespace":"","ids":[],"deleteAll":true}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Api-Key:
+      - "<PINECONE_API_KEY>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 12 Jun 2023 18:55:00 GMT
+      X-Envoy-Upstream-Service-Time:
+      - '8'
+      Grpc-Status:
+      - '0'
+      Content-Length:
+      - '2'
+      Server:
+      - envoy
+    body:
+      encoding: UTF-8
+      string: "{}"
+  recorded_at: Mon, 12 Jun 2023 18:55:00 GMT
 recorded_with: VCR 6.1.0

--- a/spec/cassettes/Pinecone_Vector/_query/successful_response/returns_a_response.yml
+++ b/spec/cassettes/Pinecone_Vector/_query/successful_response/returns_a_response.yml
@@ -2,10 +2,10 @@
 http_interactions:
 - request:
     method: post
-    uri: https://example-index-b2e8921.svc.<PINECONE_ENVIRONMENT>.pinecone.io/vectors/upsert
+    uri: https://example-index-1-b2e8921.svc.<PINECONE_ENVIRONMENT>.pinecone.io/vectors/upsert
     body:
       encoding: UTF-8
-      string: '{"vectors":[{"values":[1,2,3],"id":"1"},{"values":[0,1,-1],"id":"2"},{"values":[1,-1,0],"id":"3"}]}'
+      string: '{"vectors":[{"values":[1,2,3],"id":"1","metadata":{"genre":"comedy"}},{"values":[0,1,-1],"id":"2","metadata":{"genre":"comedy"}},{"values":[1,-1,0],"id":"3"}]}'
     headers:
       Content-Type:
       - application/json
@@ -25,9 +25,9 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Mar 2023 01:07:27 GMT
+      - Mon, 12 Jun 2023 18:54:56 GMT
       X-Envoy-Upstream-Service-Time:
-      - '87'
+      - '53'
       Grpc-Status:
       - '0'
       Content-Length:
@@ -37,10 +37,10 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"upsertedCount":3}'
-  recorded_at: Tue, 21 Mar 2023 01:07:27 GMT
+  recorded_at: Mon, 12 Jun 2023 18:54:57 GMT
 - request:
     method: post
-    uri: https://example-index-b2e8921.svc.<PINECONE_ENVIRONMENT>.pinecone.io/query
+    uri: https://example-index-1-b2e8921.svc.<PINECONE_ENVIRONMENT>.pinecone.io/query
     body:
       encoding: UTF-8
       string: '{"namespace":"","includeValues":false,"includeMetadata":true,"topK":10,"vector":[0.5,-0.5,0]}'
@@ -63,17 +63,55 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Mar 2023 01:07:27 GMT
+      - Mon, 12 Jun 2023 18:54:56 GMT
       X-Envoy-Upstream-Service-Time:
       - '1'
       Grpc-Status:
       - '0'
       Content-Length:
-      - '146'
+      - '206'
       Server:
       - envoy
     body:
       encoding: UTF-8
-      string: '{"results":[],"matches":[{"id":"3","score":1,"values":[]},{"id":"2","score":-0.5,"values":[]},{"id":"1","score":-0.5,"values":[]}],"namespace":""}'
-  recorded_at: Tue, 21 Mar 2023 01:07:27 GMT
+      string: '{"results":[],"matches":[{"id":"3","score":1,"values":[]},{"id":"2","score":-0.5,"values":[],"metadata":{"genre":"comedy"}},{"id":"1","score":-0.5,"values":[],"metadata":{"genre":"comedy"}}],"namespace":""}'
+  recorded_at: Mon, 12 Jun 2023 18:54:57 GMT
+- request:
+    method: post
+    uri: https://example-index-1-b2e8921.svc.<PINECONE_ENVIRONMENT>.pinecone.io/vectors/delete
+    body:
+      encoding: UTF-8
+      string: '{"namespace":"","ids":[],"deleteAll":true}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Api-Key:
+      - "<PINECONE_API_KEY>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 12 Jun 2023 18:54:56 GMT
+      X-Envoy-Upstream-Service-Time:
+      - '11'
+      Grpc-Status:
+      - '0'
+      Content-Length:
+      - '2'
+      Server:
+      - envoy
+    body:
+      encoding: UTF-8
+      string: "{}"
+  recorded_at: Mon, 12 Jun 2023 18:54:57 GMT
 recorded_with: VCR 6.1.0

--- a/spec/cassettes/Pinecone_Vector/_query/successful_response/returns_a_response_when_queried_with_object.yml
+++ b/spec/cassettes/Pinecone_Vector/_query/successful_response/returns_a_response_when_queried_with_object.yml
@@ -2,10 +2,10 @@
 http_interactions:
 - request:
     method: post
-    uri: https://example-index-b2e8921.svc.<PINECONE_ENVIRONMENT>.pinecone.io/vectors/upsert
+    uri: https://example-index-1-b2e8921.svc.<PINECONE_ENVIRONMENT>.pinecone.io/vectors/upsert
     body:
       encoding: UTF-8
-      string: '{"vectors":[{"values":[1,2,3],"id":"1"},{"values":[0,1,-1],"id":"2"},{"values":[1,-1,0],"id":"3"}]}'
+      string: '{"vectors":[{"values":[1,2,3],"id":"1","metadata":{"genre":"comedy"}},{"values":[0,1,-1],"id":"2","metadata":{"genre":"comedy"}},{"values":[1,-1,0],"id":"3"}]}'
     headers:
       Content-Type:
       - application/json
@@ -25,9 +25,9 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 26 Apr 2023 14:02:53 GMT
+      - Mon, 12 Jun 2023 18:54:58 GMT
       X-Envoy-Upstream-Service-Time:
-      - '236'
+      - '50'
       Grpc-Status:
       - '0'
       Content-Length:
@@ -37,10 +37,10 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"upsertedCount":3}'
-  recorded_at: Wed, 26 Apr 2023 14:02:53 GMT
+  recorded_at: Mon, 12 Jun 2023 18:54:57 GMT
 - request:
     method: post
-    uri: https://example-index-b2e8921.svc.<PINECONE_ENVIRONMENT>.pinecone.io/query
+    uri: https://example-index-1-b2e8921.svc.<PINECONE_ENVIRONMENT>.pinecone.io/query
     body:
       encoding: UTF-8
       string: '{"namespace":"","includeValues":false,"includeMetadata":true,"topK":10,"vector":[0.5,-0.5,0]}'
@@ -63,17 +63,55 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 26 Apr 2023 14:04:05 GMT
+      - Mon, 12 Jun 2023 18:54:58 GMT
       X-Envoy-Upstream-Service-Time:
-      - '2'
+      - '1'
       Grpc-Status:
       - '0'
       Content-Length:
-      - '146'
+      - '206'
       Server:
       - envoy
     body:
       encoding: UTF-8
-      string: '{"results":[],"matches":[{"id":"3","score":1,"values":[]},{"id":"2","score":-0.5,"values":[]},{"id":"1","score":-0.5,"values":[]}],"namespace":""}'
-  recorded_at: Wed, 26 Apr 2023 14:04:05 GMT
+      string: '{"results":[],"matches":[{"id":"3","score":1,"values":[]},{"id":"2","score":-0.5,"values":[],"metadata":{"genre":"comedy"}},{"id":"1","score":-0.5,"values":[],"metadata":{"genre":"comedy"}}],"namespace":""}'
+  recorded_at: Mon, 12 Jun 2023 18:54:58 GMT
+- request:
+    method: post
+    uri: https://example-index-1-b2e8921.svc.<PINECONE_ENVIRONMENT>.pinecone.io/vectors/delete
+    body:
+      encoding: UTF-8
+      string: '{"namespace":"","ids":[],"deleteAll":true}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Api-Key:
+      - "<PINECONE_API_KEY>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 12 Jun 2023 18:54:58 GMT
+      X-Envoy-Upstream-Service-Time:
+      - '8'
+      Grpc-Status:
+      - '0'
+      Content-Length:
+      - '2'
+      Server:
+      - envoy
+    body:
+      encoding: UTF-8
+      string: "{}"
+  recorded_at: Mon, 12 Jun 2023 18:54:58 GMT
 recorded_with: VCR 6.1.0

--- a/spec/cassettes/Pinecone_Vector/_query/successful_response/with_filter/returns_a_response.yml
+++ b/spec/cassettes/Pinecone_Vector/_query/successful_response/with_filter/returns_a_response.yml
@@ -2,10 +2,10 @@
 http_interactions:
 - request:
     method: post
-    uri: https://example-index-b2e8921.svc.<PINECONE_ENVIRONMENT>.pinecone.io/vectors/upsert
+    uri: https://example-index-1-b2e8921.svc.<PINECONE_ENVIRONMENT>.pinecone.io/vectors/upsert
     body:
       encoding: UTF-8
-      string: '{"vectors":[{"values":[1,2,3],"id":"1"},{"values":[0,1,-1],"id":"2"},{"values":[1,-1,0],"id":"3"}]}'
+      string: '{"vectors":[{"values":[1,2,3],"id":"1","metadata":{"genre":"comedy"}},{"values":[0,1,-1],"id":"2","metadata":{"genre":"comedy"}},{"values":[1,-1,0],"id":"3"}]}'
     headers:
       Content-Type:
       - application/json
@@ -25,9 +25,9 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 26 Apr 2023 15:00:09 GMT
+      - Mon, 12 Jun 2023 18:54:58 GMT
       X-Envoy-Upstream-Service-Time:
-      - '787'
+      - '50'
       Grpc-Status:
       - '0'
       Content-Length:
@@ -37,13 +37,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"upsertedCount":3}'
-  recorded_at: Wed, 26 Apr 2023 15:00:09 GMT
+  recorded_at: Mon, 12 Jun 2023 18:54:58 GMT
 - request:
     method: post
-    uri: https://example-index-b2e8921.svc.<PINECONE_ENVIRONMENT>.pinecone.io/query
+    uri: https://example-index-1-b2e8921.svc.<PINECONE_ENVIRONMENT>.pinecone.io/query
     body:
       encoding: UTF-8
-      string: '{"namespace":"","includeValues":false,"includeMetadata":true,"topK":10,"vector":[0.5,-0.5,0],"filter":{}}'
+      string: '{"namespace":"","includeValues":false,"includeMetadata":true,"topK":10,"vector":[0.5,-0.5,0],"filter":{"genre":{"$eq":"comedy"}}}'
     headers:
       Content-Type:
       - application/json
@@ -63,17 +63,55 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 26 Apr 2023 15:03:55 GMT
+      - Mon, 12 Jun 2023 18:54:58 GMT
       X-Envoy-Upstream-Service-Time:
-      - '3'
+      - '1'
       Grpc-Status:
       - '0'
       Content-Length:
-      - '146'
+      - '173'
       Server:
       - envoy
     body:
       encoding: UTF-8
-      string: '{"results":[],"matches":[{"id":"3","score":1,"values":[]},{"id":"2","score":-0.5,"values":[]},{"id":"1","score":-0.5,"values":[]}],"namespace":""}'
-  recorded_at: Wed, 26 Apr 2023 15:03:55 GMT
+      string: '{"results":[],"matches":[{"id":"2","score":-0.5,"values":[],"metadata":{"genre":"comedy"}},{"id":"1","score":-0.5,"values":[],"metadata":{"genre":"comedy"}}],"namespace":""}'
+  recorded_at: Mon, 12 Jun 2023 18:54:58 GMT
+- request:
+    method: post
+    uri: https://example-index-1-b2e8921.svc.<PINECONE_ENVIRONMENT>.pinecone.io/vectors/delete
+    body:
+      encoding: UTF-8
+      string: '{"namespace":"","ids":[],"deleteAll":true}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Api-Key:
+      - "<PINECONE_API_KEY>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 12 Jun 2023 18:54:59 GMT
+      X-Envoy-Upstream-Service-Time:
+      - '12'
+      Grpc-Status:
+      - '0'
+      Content-Length:
+      - '2'
+      Server:
+      - envoy
+    body:
+      encoding: UTF-8
+      string: "{}"
+  recorded_at: Mon, 12 Jun 2023 18:54:59 GMT
 recorded_with: VCR 6.1.0

--- a/spec/cassettes/Pinecone_Vector/_query/with_namespace/returns_a_response.yml
+++ b/spec/cassettes/Pinecone_Vector/_query/with_namespace/returns_a_response.yml
@@ -336,4 +336,156 @@ http_interactions:
       encoding: UTF-8
       string: '{"results":[],"matches":[{"id":"3","score":1.00000012,"values":[]},{"id":"1","score":-0.188982248,"values":[]},{"id":"2","score":-0.50000006,"values":[]}],"namespace":"example-namespace"}'
   recorded_at: Tue, 21 Mar 2023 01:00:45 GMT
+- request:
+    method: post
+    uri: https://example-index-1-b2e8921.svc.<PINECONE_ENVIRONMENT>.pinecone.io/vectors/upsert
+    body:
+      encoding: UTF-8
+      string: '{"vectors":[{"values":[1,2,3],"id":"1","metadata":{"genre":"comedy"}},{"values":[0,1,-1],"id":"2","metadata":{"genre":"comedy"}},{"values":[1,-1,0],"id":"3"}],"namespace":"example-namespace"}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Api-Key:
+      - "<PINECONE_API_KEY>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 12 Jun 2023 18:54:59 GMT
+      X-Envoy-Upstream-Service-Time:
+      - '78'
+      Grpc-Status:
+      - '0'
+      Content-Length:
+      - '19'
+      Server:
+      - envoy
+    body:
+      encoding: UTF-8
+      string: '{"upsertedCount":3}'
+  recorded_at: Mon, 12 Jun 2023 18:54:59 GMT
+- request:
+    method: post
+    uri: https://example-index-1-b2e8921.svc.<PINECONE_ENVIRONMENT>.pinecone.io/query
+    body:
+      encoding: UTF-8
+      string: '{"namespace":"example-namespace","includeValues":false,"includeMetadata":true,"topK":10,"vector":[0.5,-0.5,0]}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Api-Key:
+      - "<PINECONE_API_KEY>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 12 Jun 2023 18:54:59 GMT
+      X-Envoy-Upstream-Service-Time:
+      - '1'
+      Grpc-Status:
+      - '0'
+      Content-Length:
+      - '223'
+      Server:
+      - envoy
+    body:
+      encoding: UTF-8
+      string: '{"results":[],"matches":[{"id":"3","score":1,"values":[]},{"id":"2","score":-0.5,"values":[],"metadata":{"genre":"comedy"}},{"id":"1","score":-0.5,"values":[],"metadata":{"genre":"comedy"}}],"namespace":"example-namespace"}'
+  recorded_at: Mon, 12 Jun 2023 18:54:59 GMT
+- request:
+    method: post
+    uri: https://example-index-1-b2e8921.svc.<PINECONE_ENVIRONMENT>.pinecone.io/vectors/delete
+    body:
+      encoding: UTF-8
+      string: '{"namespace":"example-namespace","ids":[],"deleteAll":true}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Api-Key:
+      - "<PINECONE_API_KEY>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 12 Jun 2023 18:54:59 GMT
+      X-Envoy-Upstream-Service-Time:
+      - '8'
+      Grpc-Status:
+      - '0'
+      Content-Length:
+      - '2'
+      Server:
+      - envoy
+    body:
+      encoding: UTF-8
+      string: "{}"
+  recorded_at: Mon, 12 Jun 2023 18:54:59 GMT
+- request:
+    method: post
+    uri: https://example-index-1-b2e8921.svc.<PINECONE_ENVIRONMENT>.pinecone.io/vectors/delete
+    body:
+      encoding: UTF-8
+      string: '{"namespace":"","ids":[],"deleteAll":true}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Api-Key:
+      - "<PINECONE_API_KEY>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 12 Jun 2023 18:54:59 GMT
+      X-Envoy-Upstream-Service-Time:
+      - '8'
+      Grpc-Status:
+      - '0'
+      Content-Length:
+      - '2'
+      Server:
+      - envoy
+    body:
+      encoding: UTF-8
+      string: "{}"
+  recorded_at: Mon, 12 Jun 2023 18:54:59 GMT
 recorded_with: VCR 6.1.0

--- a/spec/cassettes/Pinecone_Vector/_update/successful_response/returns_a_response.yml
+++ b/spec/cassettes/Pinecone_Vector/_update/successful_response/returns_a_response.yml
@@ -114,4 +114,118 @@ http_interactions:
       encoding: UTF-8
       string: "{}"
   recorded_at: Wed, 26 Apr 2023 13:53:52 GMT
+- request:
+    method: post
+    uri: https://example-index-1-b2e8921.svc.<PINECONE_ENVIRONMENT>.pinecone.io/vectors/upsert
+    body:
+      encoding: UTF-8
+      string: '{"vectors":[{"values":[1,2,3],"id":"1"}]}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Api-Key:
+      - "<PINECONE_API_KEY>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 12 Jun 2023 18:54:55 GMT
+      X-Envoy-Upstream-Service-Time:
+      - '10'
+      Grpc-Status:
+      - '0'
+      Content-Length:
+      - '19'
+      Server:
+      - envoy
+    body:
+      encoding: UTF-8
+      string: '{"upsertedCount":1}'
+  recorded_at: Mon, 12 Jun 2023 18:54:56 GMT
+- request:
+    method: post
+    uri: https://example-index-1-b2e8921.svc.<PINECONE_ENVIRONMENT>.pinecone.io/vectors/update
+    body:
+      encoding: UTF-8
+      string: '{"id":"1","values":[1,0,3],"setMetadata":{"genre":"drama"}}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Api-Key:
+      - "<PINECONE_API_KEY>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 12 Jun 2023 18:54:56 GMT
+      X-Envoy-Upstream-Service-Time:
+      - '8'
+      Grpc-Status:
+      - '0'
+      Content-Length:
+      - '2'
+      Server:
+      - envoy
+    body:
+      encoding: UTF-8
+      string: "{}"
+  recorded_at: Mon, 12 Jun 2023 18:54:56 GMT
+- request:
+    method: post
+    uri: https://example-index-1-b2e8921.svc.<PINECONE_ENVIRONMENT>.pinecone.io/vectors/delete
+    body:
+      encoding: UTF-8
+      string: '{"namespace":"","ids":[],"deleteAll":true}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Api-Key:
+      - "<PINECONE_API_KEY>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 12 Jun 2023 18:54:56 GMT
+      X-Envoy-Upstream-Service-Time:
+      - '9'
+      Grpc-Status:
+      - '0'
+      Content-Length:
+      - '2'
+      Server:
+      - envoy
+    body:
+      encoding: UTF-8
+      string: "{}"
+  recorded_at: Mon, 12 Jun 2023 18:54:56 GMT
 recorded_with: VCR 6.1.0

--- a/spec/cassettes/Pinecone_Vector/_upsert/successful_response/returns_a_response.yml
+++ b/spec/cassettes/Pinecone_Vector/_upsert/successful_response/returns_a_response.yml
@@ -38,4 +38,80 @@ http_interactions:
       encoding: UTF-8
       string: '{"upsertedCount":1}'
   recorded_at: Tue, 21 Mar 2023 01:00:43 GMT
+- request:
+    method: post
+    uri: https://example-index-1-b2e8921.svc.<PINECONE_ENVIRONMENT>.pinecone.io/vectors/upsert
+    body:
+      encoding: UTF-8
+      string: '{"vectors":[{"values":[1,2,3],"id":"1"}]}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Api-Key:
+      - "<PINECONE_API_KEY>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 12 Jun 2023 18:54:52 GMT
+      X-Envoy-Upstream-Service-Time:
+      - '8'
+      Grpc-Status:
+      - '0'
+      Content-Length:
+      - '19'
+      Server:
+      - envoy
+    body:
+      encoding: UTF-8
+      string: '{"upsertedCount":1}'
+  recorded_at: Mon, 12 Jun 2023 18:54:52 GMT
+- request:
+    method: post
+    uri: https://example-index-1-b2e8921.svc.<PINECONE_ENVIRONMENT>.pinecone.io/vectors/delete
+    body:
+      encoding: UTF-8
+      string: '{"namespace":"","ids":[],"deleteAll":true}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Api-Key:
+      - "<PINECONE_API_KEY>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 12 Jun 2023 18:54:52 GMT
+      X-Envoy-Upstream-Service-Time:
+      - '8'
+      Grpc-Status:
+      - '0'
+      Content-Length:
+      - '2'
+      Server:
+      - envoy
+    body:
+      encoding: UTF-8
+      string: "{}"
+  recorded_at: Mon, 12 Jun 2023 18:54:53 GMT
 recorded_with: VCR 6.1.0

--- a/spec/cassettes/Pinecone_Vector/_upsert/unsuccessful_response/returns_a_response.yml
+++ b/spec/cassettes/Pinecone_Vector/_upsert/unsuccessful_response/returns_a_response.yml
@@ -36,4 +36,78 @@ http_interactions:
       encoding: UTF-8
       string: ": Root element must be a message."
   recorded_at: Tue, 21 Mar 2023 01:00:44 GMT
+- request:
+    method: post
+    uri: https://example-index-1-b2e8921.svc.<PINECONE_ENVIRONMENT>.pinecone.io/vectors/upsert
+    body:
+      encoding: UTF-8
+      string: '"foo"'
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Api-Key:
+      - "<PINECONE_API_KEY>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Content-Type:
+      - text/plain
+      Content-Length:
+      - '33'
+      Date:
+      - Mon, 12 Jun 2023 18:54:53 GMT
+      Server:
+      - envoy
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: ": Root element must be a message."
+  recorded_at: Mon, 12 Jun 2023 18:54:53 GMT
+- request:
+    method: post
+    uri: https://example-index-1-b2e8921.svc.<PINECONE_ENVIRONMENT>.pinecone.io/vectors/delete
+    body:
+      encoding: UTF-8
+      string: '{"namespace":"","ids":[],"deleteAll":true}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Api-Key:
+      - "<PINECONE_API_KEY>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 12 Jun 2023 18:54:53 GMT
+      X-Envoy-Upstream-Service-Time:
+      - '8'
+      Grpc-Status:
+      - '0'
+      Content-Length:
+      - '2'
+      Server:
+      - envoy
+    body:
+      encoding: UTF-8
+      string: "{}"
+  recorded_at: Mon, 12 Jun 2023 18:54:53 GMT
 recorded_with: VCR 6.1.0

--- a/spec/cassettes/missing_index.yml
+++ b/spec/cassettes/missing_index.yml
@@ -25,7 +25,7 @@ http_interactions:
       Content-Type:
       - text/plain; charset=UTF-8
       Date:
-      - Fri, 24 Feb 2023 20:42:54 GMT
+      - Mon, 12 Jun 2023 18:47:50 GMT
       X-Envoy-Upstream-Service-Time:
       - '5'
       Content-Length:
@@ -35,7 +35,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '404: Not Found'
-  recorded_at: Fri, 24 Feb 2023 20:42:54 GMT
+  recorded_at: Mon, 12 Jun 2023 18:47:50 GMT
 - request:
     method: get
     uri: https://controller.<PINECONE_ENVIRONMENT>.pinecone.io/databases/missing-index
@@ -61,43 +61,7 @@ http_interactions:
       Content-Type:
       - text/plain; charset=UTF-8
       Date:
-      - Tue, 21 Mar 2023 01:00:45 GMT
-      X-Envoy-Upstream-Service-Time:
-      - '7'
-      Content-Length:
-      - '14'
-      Server:
-      - envoy
-    body:
-      encoding: UTF-8
-      string: '404: Not Found'
-  recorded_at: Tue, 21 Mar 2023 01:00:45 GMT
-- request:
-    method: get
-    uri: https://controller.<PINECONE_ENVIRONMENT>.pinecone.io/databases/missing-index
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      Api-Key:
-      - "<PINECONE_API_KEY>"
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Content-Type:
-      - text/plain; charset=UTF-8
-      Date:
-      - Tue, 21 Mar 2023 01:04:33 GMT
+      - Mon, 12 Jun 2023 18:51:08 GMT
       X-Envoy-Upstream-Service-Time:
       - '3'
       Content-Length:
@@ -107,5 +71,41 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '404: Not Found'
-  recorded_at: Tue, 21 Mar 2023 01:04:33 GMT
+  recorded_at: Mon, 12 Jun 2023 18:51:08 GMT
+- request:
+    method: get
+    uri: https://controller.<PINECONE_ENVIRONMENT>.pinecone.io/databases/missing-index
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Api-Key:
+      - "<PINECONE_API_KEY>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Mon, 12 Jun 2023 18:55:00 GMT
+      X-Envoy-Upstream-Service-Time:
+      - '5'
+      Content-Length:
+      - '14'
+      Server:
+      - envoy
+    body:
+      encoding: UTF-8
+      string: '404: Not Found'
+  recorded_at: Mon, 12 Jun 2023 18:55:00 GMT
 recorded_with: VCR 6.1.0

--- a/spec/cassettes/use_index.yml
+++ b/spec/cassettes/use_index.yml
@@ -19,23 +19,59 @@ http_interactions:
       - Ruby
   response:
     status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Mon, 12 Jun 2023 18:34:32 GMT
+      X-Envoy-Upstream-Service-Time:
+      - '8'
+      Content-Length:
+      - '14'
+      Server:
+      - envoy
+    body:
+      encoding: UTF-8
+      string: '404: Not Found'
+  recorded_at: Mon, 12 Jun 2023 18:34:32 GMT
+- request:
+    method: get
+    uri: https://controller.<PINECONE_ENVIRONMENT>.pinecone.io/databases/example-index-1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Api-Key:
+      - "<PINECONE_API_KEY>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      User-Agent:
+      - Ruby
+  response:
+    status:
       code: 200
       message: OK
     headers:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 26 Apr 2023 15:52:39 GMT
+      - Mon, 12 Jun 2023 18:55:01 GMT
       X-Envoy-Upstream-Service-Time:
-      - '4'
+      - '5'
       Content-Length:
-      - '263'
+      - '267'
       Server:
       - envoy
     body:
       encoding: UTF-8
-      string: '{"database":{"name":"example-index","metric":"dotproduct","dimension":3,"replicas":2,"shards":1,"pods":2,"pod_type":"p1.x1"},"status":{"waiting":[],"crashed":[],"host":"example-index-b2e8921.svc.<PINECONE_ENVIRONMENT>.pinecone.io","port":433,"state":"Ready","ready":true}}
+      string: '{"database":{"name":"example-index-1","metric":"dotproduct","dimension":3,"replicas":1,"shards":1,"pods":1,"pod_type":"p1.x1"},"status":{"waiting":[],"crashed":[],"host":"example-index-1-b2e8921.svc.<PINECONE_ENVIRONMENT>.pinecone.io","port":433,"state":"Ready","ready":true}}
 
         '
-  recorded_at: Wed, 26 Apr 2023 15:52:39 GMT
+  recorded_at: Mon, 12 Jun 2023 18:55:01 GMT
 recorded_with: VCR 6.1.0


### PR DESCRIPTION
Also, Fixing Vector Specs to work with NO_VCR=true

Oddly, if a filter is present `{}` pinecone API doesn't accept delete_all or ids in the delete action