### PR TITLE
New API integration / Serverless proof of concept

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ pinecone.create_index({
   "metric": "dotproduct",
   "name": "example-index",
   "dimension": 3,
+  "spec": {
+        "pod": {
+          "environment": "gcp-starter",
+          "pod_type": "starter"
+        }
+      }
 })
 ```
 

--- a/lib/pinecone/collection.rb
+++ b/lib/pinecone/collection.rb
@@ -3,7 +3,7 @@ module Pinecone
     include HTTParty
 
     def initialize
-      self.class.base_uri "https://controller.#{Pinecone.configuration.environment}.pinecone.io"
+      self.class.base_uri "https://api.pinecone.io"
 
       @headers = {
         "Content-Type" => "application/json",

--- a/lib/pinecone/index.rb
+++ b/lib/pinecone/index.rb
@@ -3,7 +3,7 @@ module Pinecone
     include HTTParty
 
     def initialize
-      self.class.base_uri "https://controller.#{Pinecone.configuration.environment}.pinecone.io"
+      self.class.base_uri "https://api.pinecone.io"
       @headers = {
         "Content-Type" => "application/json",
         "Accept" => "application/json",
@@ -12,25 +12,25 @@ module Pinecone
     end
 
     def list
-      self.class.get('/databases', options)
+      self.class.get('/indexes', options)
     end
 
     def describe(index_name)
-      self.class.get("/databases/#{index_name}", options)
+      self.class.get("/indexes/#{index_name}", options)
     end
     
     def create(body)
       payload = options.merge(body: body.to_json)
-      self.class.post('/databases', payload)
+      self.class.post('/indexes', payload)
     end
 
     def delete(index_name)
-      self.class.delete("/databases/#{index_name}", options)
+      self.class.delete("/indexes/#{index_name}", options)
     end
 
     def configure(index_name, body)
       payload = options.merge(body: body.to_json)
-      self.class.patch("/databases/#{index_name}", payload)
+      self.class.patch("/indexes/#{index_name}", payload)
     end
 
     def options

--- a/lib/pinecone/vector.rb
+++ b/lib/pinecone/vector.rb
@@ -82,7 +82,7 @@ module Pinecone
     def set_base_uri(index_name)
       index_description = Pinecone::Index.new.describe(index_name)
       raise Pinecone::IndexNotFoundError, "Index #{index_name} does not exist" if index_description.code != 200
-      uri = index_description.parsed_response["status"]["host"]
+      uri = index_description.parsed_response["host"]
       "https://#{uri}"
     end
   end

--- a/spec/pinecone/collections_spec.rb
+++ b/spec/pinecone/collections_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Pinecone::Collection do
   let(:valid_attributes) {
     {
       name: "test-collection",
-      source: "example-index"
+      source: "test-index"
     }
   }
 
@@ -17,7 +17,7 @@ RSpec.describe Pinecone::Collection do
     it "returns a response with list of collections" do
       expect(response).to be_a(HTTParty::Response)
       expect(response.code).to eq(200)
-      expect(response.parsed_response).to be_a(Array)
+      expect(response.parsed_response).to be_a(Hash)
     end
   end
 
@@ -58,8 +58,10 @@ RSpec.describe Pinecone::Collection do
         expect(response.code).to eq(200)
         expect(response.parsed_response).to eq({
           "name"=>"test-collection", 
+          "size"=>0,
           "status"=>"Initializing", 
-          "dimension"=>3
+          "dimension"=>3,
+          "vector_count"=>0
         })
       end
     end

--- a/spec/pinecone/vector_spec.rb
+++ b/spec/pinecone/vector_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe Pinecone::Vector do
 
         expect(response).to be_a(HTTParty::Response)
         expect(response.code).to eq(200)
-        expect(response.parsed_response).to eq({
+        expect(response.parsed_response).to match(
           "namespace" => "",
           "vectors" => {
             "1" => {
@@ -102,8 +102,9 @@ RSpec.describe Pinecone::Vector do
               "id" => "2",
               "values" => [1, 2, 3]
             }
-          }
-        })
+          },
+          "usage" => { "readUnits" => 2 }
+        )
       end
     end
   end


### PR DESCRIPTION
This is a proof of concept which resolves #29

Unfortunately it also breaks the old API, because now the `#list_indexes` method returns a hash with indexes rather than an array of index names. So I wasn't sure if this gem should also break API and bump to the new major version or keep the current gem API, by mapping a Hash of indexes to the array of index names.

Also, because I only have the starter account I couldn't test all scenarios. So the VCR cassetes are not up to date in this PR.