### PR TITLE
Bump dependencies, add Ruby 3.3 to test matrix

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['3.2']
+        ruby-version: ['3.2', '3.3']
     env:
       PINECONE_API_KEY: sekret
       PINECONE_ENVIRONMENT: us-east1-gcp

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     pinecone (1.0.1)
       dry-struct (~> 1.6.0)
       dry-validation (~> 1.10.0)
-      httparty (~> 0.21.0)
+      httparty (~> 0.22.0)
 
 GEM
   remote: https://rubygems.org/
@@ -16,6 +16,7 @@ GEM
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
+    csv (3.3.0)
     debug (1.7.2)
       irb (>= 1.5.0)
       reline (>= 0.3.1)
@@ -59,7 +60,8 @@ GEM
       dry-schema (>= 1.12, < 2)
       zeitwerk (~> 2.6)
     hashdiff (1.0.1)
-    httparty (0.21.0)
+    httparty (0.22.0)
+      csv
       mini_mime (>= 1.0.0)
       multi_xml (>= 0.5.2)
     ice_nine (0.11.2)

--- a/pinecone.gemspec
+++ b/pinecone.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.metadata = {"source_code_uri" => "https://github.com/ScotterC/pinecone"}
   s.license = "MIT"
 
-  s.add_dependency "httparty", "~> 0.21.0"
+  s.add_dependency "httparty", "~> 0.22.0"
   s.add_dependency "dry-struct", "~> 1.6.0"
   s.add_dependency "dry-validation", "~> 1.10.0"
 end


### PR DESCRIPTION
httparty 0.21.0 is throwing deprecation warnings in Rails on ruby 3.3:

> ~/.rbenv/versions/3.3.2/lib/ruby/gems/3.3.0/gems/bootsnap-1.18.3/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30: warning: ~/.rbenv/versions/3.3.2/lib/ruby/3.3.0/csv.rb was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add csv to your Gemfile or gemspec. Also contact author of httparty-0.21.0 to add csv into its gemspec.

This PR adds testing for Ruby 3.3, and changes the httparty dependency to `~> 0.22.0`. 