### PR TITLE
Make control plane base_uri configurable for Pinecone Local support

### DIFF
--- a/lib/pinecone.rb
+++ b/lib/pinecone.rb
@@ -15,13 +15,15 @@ module Pinecone
   class IndexNotFoundError < StandardError; end
 
   class Configuration
-    attr_writer :api_key, :base_uri, :environment, :silence_deprecation_warnings
-    attr_accessor :host
+    DEFAULT_BASE_URI = "https://api.pinecone.io"
+
+    attr_writer :api_key, :environment, :silence_deprecation_warnings
+    attr_accessor :host, :base_uri
 
     def initialize
       @api_key = nil
       @environment = nil
-      @base_uri = nil
+      @base_uri = DEFAULT_BASE_URI
       @host = nil
       @silence_deprecation_warnings = false
     end
@@ -30,12 +32,6 @@ module Pinecone
       return @api_key if @api_key
 
       raise ConfigurationError, "Pinecone API key not set"
-    end
-
-    def base_uri
-      return @base_uri if @base_uri
-
-      raise ConfigurationError, "Pinecone domain not set"
     end
 
     def environment

--- a/lib/pinecone/collection.rb
+++ b/lib/pinecone/collection.rb
@@ -6,7 +6,7 @@ module Pinecone
     parser Pinecone::ResponseParser
 
     def initialize
-      self.class.base_uri "https://api.pinecone.io"
+      self.class.base_uri Pinecone.configuration.base_uri
 
       @headers = {
         "Content-Type" => "application/json",

--- a/lib/pinecone/index.rb
+++ b/lib/pinecone/index.rb
@@ -6,7 +6,7 @@ module Pinecone
     parser Pinecone::ResponseParser
 
     def initialize
-      self.class.base_uri "https://api.pinecone.io"
+      self.class.base_uri Pinecone.configuration.base_uri
       @headers = {
         "Content-Type" => "application/json",
         "Accept" => "application/json",

--- a/lib/pinecone/vector.rb
+++ b/lib/pinecone/vector.rb
@@ -18,9 +18,9 @@ module Pinecone
         @base_uri = if host.start_with?("http://", "https://")
           host
         elsif host.start_with?("localhost")
-          "http://#{host}" # Use HTTP for localhost
+          "http://#{host}"
         else
-          "https://#{host}" # Use HTTPS for production hosts
+          "https://#{host}"
         end
       elsif index_name
         # Legacy path: call describe_index

--- a/spec/pinecone/index_spec.rb
+++ b/spec/pinecone/index_spec.rb
@@ -7,12 +7,15 @@ RSpec.describe Pinecone::Index do
     skip "Local database container not available" unless database_available?
   end
 
-  let(:client) do
-    # Use local database container only
-    index_client = Pinecone::Index.new
-    index_client.class.base_uri "http://localhost:5080"
-    index_client
+  before(:each) do
+    Pinecone.configuration.base_uri = "http://localhost:5080"
   end
+
+  after(:each) do
+    Pinecone.configuration.base_uri = Pinecone::Configuration::DEFAULT_BASE_URI
+  end
+
+  let(:client) { Pinecone::Index.new }
   let(:valid_attributes) do
     {
       metric: "dotproduct",

--- a/spec/support/local_container_helpers.rb
+++ b/spec/support/local_container_helpers.rb
@@ -80,21 +80,11 @@ module LocalContainerHelpers
     @database_client ||= begin
       Pinecone.configure do |config|
         config.api_key = "dummy-key"
+        config.base_uri = DATABASE_URL
         config.silence_deprecation_warnings = true
       end
 
-      # Create a client that can talk to the database emulator for control plane operations
-      client = Pinecone::Client.new
-      # Override the base_uri for control plane operations
-      Pinecone::Index.any_instance.define_singleton_method(:initialize) do
-        self.class.base_uri "http://#{DATABASE_HOST}"
-        @headers = {
-          "Content-Type" => "application/json",
-          "Accept" => "application/json",
-          "Api-Key" => "dummy-key"
-        }
-      end
-      client
+      Pinecone::Client.new
     end
   end
 


### PR DESCRIPTION
## Summary

The control plane (`Index`, `Collection`) hardcoded `https://api.pinecone.io`, making it impossible to use Pinecone Local's database emulator for index management without monkey-patching.

This PR makes `base_uri` configurable with a default of `https://api.pinecone.io` — fully backward compatible for cloud users, and now usable with local containers.

The data plane (`Vector`) already supports `http://` prefixes on host parameters, so no changes are needed there. Users just need to pass `host: "http://dense-index:5081"` instead of `host: "dense-index:5081"`.

### Usage

```ruby
# Cloud (default, nothing changes)
Pinecone.configure do |config|
  config.api_key = "pc-real-key"
end

# Local development
Pinecone.configure do |config|
  config.api_key = "anything"
  config.base_uri = "http://localhost:5080"  # control plane
end
client.index(host: "http://localhost:5081")  # data plane (already worked)
```

### Changes

- `Configuration#base_uri` defaults to `https://api.pinecone.io` instead of raising
- `Index` and `Collection` read `base_uri` from config instead of hardcoding
- Removed `define_singleton_method` monkey-patch from test helpers

Closes #47, closes #51

## Test plan

- [x] All specs pass against local Pinecone containers
- [x] StandardRB lint clean
- [ ] Verify CI passes with container-based tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)